### PR TITLE
Responsive padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,25 @@
 .content {
-  padding-right: 18em;
-  padding-left: 18em;
+  padding-right: 18rem;
+  padding-left: 18rem;
   font-size: large;
   text-align: justify;
   line-height: 1.5;
 }
+
+@media (max-width: 1024px) {
+  .content {
+    padding-right: 10rem;
+    padding-left: 10rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+}
+
 
 body {
   font-family: "Podkova", Courier, monospace;


### PR DESCRIPTION
Added media queries to reduce padding on small screens

Changed site shown on an iPhone SE
![responsive_iphone-se](https://github.com/user-attachments/assets/042b332e-0694-404d-8db7-59ed58e8314b)

Changed site shown on desktop:
![desktop](https://github.com/user-attachments/assets/de6bdd43-ad14-4473-8e20-1b413742e983)

Site prior to changes on an iPhone SE:
![prior_iphone-se](https://github.com/user-attachments/assets/21996415-c2d8-4803-8362-6eb1adfaba8a)

I was using DevTools to test how it would look on mobile but took the screenshot natively to confirm.
